### PR TITLE
feat: Implement Pocket import, content fetching, iCloud (Dart)

### DIFF
--- a/lib/app/app_widget.dart
+++ b/lib/app/app_widget.dart
@@ -1,50 +1,195 @@
+import 'dart:async'; // For StreamSubscription
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'; 
 import 'package:readlyit/app/ui/screens/home_screen.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Import generated localizations
-import 'package:readlyit/main.dart'; // Import main.dart to access MyHomePage for now
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-class AppWidget extends StatelessWidget {
+// Imports for uni_links
+import 'package:uni_links/uni_links.dart';
+import 'package:flutter/services.dart' show PlatformException;
+
+// Import your providers
+import 'package:readlyit/features/articles/presentation/providers/article_providers.dart';
+
+
+class AppWidget extends ConsumerStatefulWidget { 
   const AppWidget({super.key});
+
+  @override
+  ConsumerState<AppWidget> createState() => _AppWidgetState(); 
+}
+
+class _AppWidgetState extends ConsumerState<AppWidget> { 
+  StreamSubscription? _subUniLinks;
+
+  @override
+  void initState() {
+    super.initState();
+    _initUniLinks();
+  }
+
+  @override
+  void dispose() {
+    _subUniLinks?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _initUniLinks() async {
+    try {
+      // Listen to incoming links when the app is already running
+      _subUniLinks = uriLinkStream.listen((Uri? uri) {
+        if (uri != null && mounted) {
+          _handleIncomingLink(uri);
+        }
+      }, onError: (err) {
+        if (mounted) {
+          print('uni_links: Error listening to link stream: $err');
+          // Optionally show a toast/snackbar
+          ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+            SnackBar(content: Text('Error receiving app link: $err')),
+          );
+        }
+      });
+
+      // Check for initial link if the app was opened by a link
+      final initialUri = await getInitialUri();
+      if (initialUri != null && mounted) {
+        _handleIncomingLink(initialUri);
+      }
+    } on PlatformException catch (e) {
+      print('uni_links: Failed to get initial URI: $e');
+      if (mounted) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          SnackBar(content: Text('Error processing initial app link: ${e.message}')),
+        );
+      }
+    } catch (e) {
+      print('uni_links: An unexpected error occurred: $e');
+       if (mounted) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          SnackBar(content: Text('An unexpected error occurred with app links: $e')),
+        );
+      }
+    }
+  }
+
+  void _handleIncomingLink(Uri uri) {
+    print('uni_links: Received incoming URI: $uri');
+    // Check if this is the Pocket auth callback
+    if (uri.scheme == 'readlyit' && uri.host == 'pocket-auth') {
+      final scaffoldMessenger = ScaffoldMessenger.maybeOf(context);
+      
+      scaffoldMessenger?.showSnackBar(
+        const SnackBar(content: Text('Finalizing Pocket authentication...')),
+      );
+
+      ref.read(articlesListProvider.notifier)
+          .completePocketAuthenticationAndFetchArticles()
+          .then((errorMessage) {
+        if (mounted) { 
+          if (errorMessage != null) {
+            print('Pocket auth callback: Error - $errorMessage');
+            scaffoldMessenger?.showSnackBar(
+              SnackBar(content: Text('Pocket Authentication Failed: $errorMessage')), 
+            );
+          } else {
+            print('Pocket auth callback: Success!');
+            scaffoldMessenger?.showSnackBar(
+              const SnackBar(content: Text('Pocket Authentication Successful! Articles imported.')), 
+            );
+            ref.invalidate(pocketIsAuthenticatedProvider);
+          }
+        }
+      }).catchError((e) {
+        print('Pocket auth callback: Error calling completePocketAuthenticationAndFetchArticles: $e');
+        if (mounted) {
+          scaffoldMessenger?.showSnackBar(
+              SnackBar(content: Text('Error processing Pocket login: ${e.toString()}')) 
+          );
+        }
+      });
+    } else {
+      print('uni_links: Received URI is not for Pocket auth: $uri');
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ReadLyit',
-      themeMode: ThemeMode.system, // Respect system light/dark mode
+      themeMode: ThemeMode.system, 
       theme: ThemeData(
         useMaterial3: true,
         brightness: Brightness.light,
-        colorSchemeSeed: Colors.blueAccent, // Keep this or change
-        // Example: Customize further
-        // appBarTheme: const AppBarTheme(
-        //   backgroundColor: Colors.blueAccent,
-        //   foregroundColor: Colors.white,
-        //   elevation: 0,
-        // ),
-        // floatingActionButtonTheme: FloatingActionButtonThemeData(
-        //   backgroundColor: Colors.blueAccent[700],
-        //   foregroundColor: Colors.white,
-        // ),
-        // cardTheme: CardTheme(
-        //   elevation: 0.5,
-        //   shape: RoundedRectangleBorder(
-        //     borderRadius: BorderRadius.circular(8.0),
-        //     side: BorderSide(color: Colors.grey.shade300, width: 0.5)
-        //   )
-        // )
+        colorSchemeSeed: Colors.blueAccent, 
       ),
       darkTheme: ThemeData(
         useMaterial3: true,
         brightness: Brightness.dark,
-        colorSchemeSeed: Colors.blueAccent, // Seed for dark theme generation
-        // Example: Customize dark theme further if needed
-        // appBarTheme: AppBarTheme(
-        //   backgroundColor: Colors.grey[900],
-        // ),
+        colorSchemeSeed: Colors.blueAccent, 
       ),
-      home: const HomeScreen(),
-      debugShowCheckedModeBanner: false, // Optional: remove debug banner
-      // ... localization delegates etc.
+      home: const HomeScreen(), 
+      localizationsDelegates: AppLocalizations.localizationsDelegates, 
+      supportedLocales: AppLocalizations.supportedLocales,     
+      debugShowCheckedModeBanner: false,
     );
   }
 }
+
+// PLATFORM SETUP FOR UNI_LINKS (Custom URL Scheme: readlyit://pocket-auth)
+//
+// **Android:**
+// Add the following intent-filter to your <activity> tag in `android/app/src/main/AndroidManifest.xml`:
+// <!-- Within the <application> tag, find your <activity> tag -->
+// <!-- The android:name for the activity should be ".MainActivity" or your custom one -->
+// <activity ...>
+//   <!-- Existing intent-filters, if any -->
+//   <intent-filter>
+//     <action android:name="android.intent.action.VIEW" />
+//     <category android:name="android.intent.category.DEFAULT" />
+//     <category android:name="android.intent.category.BROWSABLE" />
+//     <data android:scheme="readlyit" android:host="pocket-auth" />
+//   </intent-filter>
+// </activity>
+//
+// **iOS:**
+// Add the following to your `ios/Runner/Info.plist` file:
+// <key>CFBundleURLTypes</key>
+// <array>
+//   <dict>
+//     <key>CFBundleTypeRole</key>
+//     <string>Editor</string>
+//     <key>CFBundleURLName</key>
+//     <string>com.example.readlyit</string> <!-- IMPORTANT: Use your actual bundle ID -->
+//     <key>CFBundleURLSchemes</key>
+//     <array>
+//       <string>readlyit</string>
+//     </array>
+//   </dict>
+// </array>
+//
+// **macOS:**
+// Add the following to your `macos/Runner/Info.plist` file:
+// <key>CFBundleURLTypes</key>
+// <array>
+//   <dict>
+//     <key>CFBundleTypeRole</key>
+//     <string>Editor</string>
+//     <key>CFBundleURLName</key>
+//     <string>com.example.readlyit</string> <!-- IMPORTANT: Use your actual bundle ID -->
+//     <key>CFBundleURLSchemes</key>
+//     <array>
+//       <string>readlyit</string>
+//     </array>
+//   </dict>
+// </array>
+//
+// Make sure to replace "com.example.readlyit" with your actual application's bundle ID 
+// in the iOS and macOS Info.plist files.
+// The host "pocket-auth" is specified in the Android <data> tag. 
+// For iOS/macOS, the scheme 'readlyit' is registered, and the Dart code
+// `_handleIncomingLink` further filters by checking `uri.host == 'pocket-auth'`.
+//
+// After adding these configurations, you may need to rebuild your app for the changes to take effect.
+// For Android, ensure your `android/app/build.gradle` has `minSdkVersion 19` or higher for uni_links.
+// Check the uni_links package documentation for the most up-to-date setup instructions.

--- a/lib/app/ui/screens/home_screen.dart
+++ b/lib/app/ui/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Import for localization
 import 'package:readlyit/features/articles/data/models/article_model.dart';
 import 'package:readlyit/features/articles/presentation/providers/article_providers.dart';
 import 'package:readlyit/features/articles/presentation/screens/article_view_screen.dart'; // Add this import
@@ -17,30 +18,30 @@ class HomeScreen extends ConsumerWidget {
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title: const Text('Add New Article'), // Replace with localized string
+          title: Text(AppLocalizations.of(dialogContext)!.addArticleTitle),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               TextField(
                 controller: urlController,
-                decoration: const InputDecoration(hintText: 'Enter article URL'), // Replace with localized string
+                decoration: InputDecoration(hintText: AppLocalizations.of(dialogContext)!.enterArticleUrlHint),
                 keyboardType: TextInputType.url,
               ),
               TextField(
                 controller: titleController,
-                decoration: const InputDecoration(hintText: 'Enter title (optional)'), // Replace with localized string
+                decoration: InputDecoration(hintText: AppLocalizations.of(dialogContext)!.enterArticleTitleHint),
               ),
             ],
           ),
           actions: <Widget>[
             TextButton(
-              child: const Text('Cancel'), // Replace with localized string
+              child: Text(AppLocalizations.of(dialogContext)!.buttonCancel),
               onPressed: () {
                 Navigator.of(dialogContext).pop();
               },
             ),
             TextButton(
-              child: const Text('Save'), // Replace with localized string
+              child: Text(AppLocalizations.of(dialogContext)!.buttonSave),
               onPressed: () {
                 final url = urlController.text;
                 final title = titleController.text.isNotEmpty ? titleController.text : url;
@@ -53,8 +54,10 @@ class HomeScreen extends ConsumerWidget {
                   ref.read(articlesListProvider.notifier).addArticle(newArticle);
                   Navigator.of(dialogContext).pop();
                 } else {
+                  // Use the context from the HomeScreen build method for ScaffoldMessenger
+                  // if dialogContext might be popped before SnackBar is shown.
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('URL cannot be empty.')), // Replace with localized string
+                    SnackBar(content: Text(AppLocalizations.of(context)!.errorUrlCannotBeEmpty)),
                   );
                 }
               },
@@ -70,17 +73,17 @@ class HomeScreen extends ConsumerWidget {
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title: const Text('Delete Article?'), // Replace with localized string
-          content: Text('Are you sure you want to delete "${article.title}"?'), // Replace with localized string
+          title: Text(AppLocalizations.of(dialogContext)!.deleteArticleTitle),
+          content: Text(AppLocalizations.of(dialogContext)!.confirmDeleteArticleContent(article.title)),
           actions: <Widget>[
             TextButton(
-              child: const Text('Cancel'), // Replace with localized string
+              child: Text(AppLocalizations.of(dialogContext)!.buttonCancel),
               onPressed: () {
                 Navigator.of(dialogContext).pop();
               },
             ),
             TextButton(
-              child: const Text('Delete'), // Replace with localized string
+              child: Text(AppLocalizations.of(dialogContext)!.buttonDelete),
               style: TextButton.styleFrom(foregroundColor: Colors.red),
               onPressed: () {
                 ref.read(articlesListProvider.notifier).deleteArticle(article.id);
@@ -96,24 +99,30 @@ class HomeScreen extends ConsumerWidget {
   @override
   // ... (_showAddArticleDialog, _confirmDeleteArticle remain the same)
 
-  void _initiatePocketImport(BuildContext context, WidgetRef ref) {
-    // For now, just a placeholder. Later, this will call the PocketService.
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Pocket Import Initiated (Placeholder)')), // Replace with localized string
+  // Modify this method in HomeScreen
+  void _initiatePocketImport(BuildContext context, WidgetRef ref) async { // Make it async
+    final articlesNotifier = ref.read(articlesListProvider.notifier);
+    final scaffoldMessenger = ScaffoldMessenger.of(context); // Cache ScaffoldMessenger
+
+    // Show some immediate feedback
+    scaffoldMessenger.showSnackBar(
+      const SnackBar(content: Text('Connecting to Pocket...')), // Replace with localized string
     );
-    // Example of how it might look later:
-    // ref.read(pocketServiceProvider).authenticateAndFetchArticles().then((success) {
-    //   if (success) {
-    //     ref.read(articlesListProvider.notifier).refresh();
-    //     ScaffoldMessenger.of(context).showSnackBar(
-    //       const SnackBar(content: Text('Pocket articles imported!')),
-    //     );
-    //   } else {
-    //     ScaffoldMessenger.of(context).showSnackBar(
-    //       const SnackBar(content: Text('Pocket import failed.')),
-    //     );
-    //   }
-    // });
+
+    final errorMessage = await articlesNotifier.initiatePocketAuthentication();
+
+    if (errorMessage != null) {
+      scaffoldMessenger.showSnackBar(
+        SnackBar(content: Text('Pocket Connection Failed: $errorMessage')), // Replace with localized string
+      );
+    } else {
+      // On successful launch of URL, PocketService will handle the redirect.
+      // Actual fetching of articles will happen after callback.
+      // For now, just inform the user that they need to check their browser.
+      scaffoldMessenger.showSnackBar(
+        const SnackBar(content: Text('Please authorize with Pocket in your browser.')), // Replace with localized string
+      );
+    }
   }
 
   @override
@@ -122,26 +131,24 @@ class HomeScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: custom_widgets.CustomAppBar(
-        titleText: 'ReadLyit Articles', // Replace with localized string
+        titleText: AppLocalizations.of(context)!.homeScreenTitle, // Localized AppBar title
         onPocketImport: () => _initiatePocketImport(context, ref), // Pass the callback
       ),
       body: articlesAsyncValue.when(
         data: (articles) {
           if (articles.isEmpty) {
-            return const Center(child: Text('No articles saved yet. Add one!')); // Replace with localized string
+            return Center(child: Text(AppLocalizations.of(context)!.articlesListEmpty));
           }
-          return ListView.builder(
-            itemCount: articles.length,
-            itemBuilder: (context, index) {
-              final article = articles[index];
-              // Determine padding based on screen width
-              final horizontalPadding = MediaQuery.of(context).size.width > 600 ? 32.0 : 16.0;
 
-              return Padding( // Add padding around ListTile
-                padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: 4.0),
-                child: Card( // Wrap ListTile in a Card for better visual separation
+          return LayoutBuilder( // Use LayoutBuilder
+            builder: (context, constraints) {
+              // Define a common item builder function to reduce duplication
+              Widget articleItemBuilder(BuildContext context, ArticleModel article, bool isGridView) {
+                return Card(
                   elevation: 0.5,
-                  margin: const EdgeInsets.symmetric(vertical: 4.0), // Consistent margin for card
+                  // Margin for GridView items can be handled by grid spacing or here
+                  // Margin for ListView items is handled by Padding wrapper
+                  margin: isGridView ? const EdgeInsets.all(4.0) : const EdgeInsets.symmetric(vertical: 4.0),
                   child: ListTile(
                     leading: Checkbox(
                       value: article.isRead,
@@ -155,13 +162,19 @@ class HomeScreen extends ConsumerWidget {
                       article.title,
                       style: TextStyle(
                         decoration: article.isRead ? TextDecoration.lineThrough : null,
-                        color: article.isRead ? Colors.grey[600] : null, // Adjusted grey for readability
+                        color: article.isRead ? Colors.grey[600] : null,
                       ),
+                      maxLines: isGridView ? 3 : 2, // More lines for title in grid view
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    subtitle: Text(article.url, maxLines: 1, overflow: TextOverflow.ellipsis),
+                    subtitle: Text(
+                        article.url, 
+                        maxLines: 1, 
+                        overflow: TextOverflow.ellipsis
+                    ),
                     trailing: IconButton(
                       icon: const Icon(Icons.delete_outline, color: Colors.redAccent),
-                      tooltip: 'Delete Article', // Replace with localized string
+                      tooltip: AppLocalizations.of(context)!.tooltipDeleteArticle,
                       onPressed: () => _confirmDeleteArticle(context, ref, article),
                     ),
                     onTap: () {
@@ -173,6 +186,53 @@ class HomeScreen extends ConsumerWidget {
                       );
                     },
                   ),
+                );
+              }
+
+              if (constraints.maxWidth < 600) {
+                // Phone layout: ListView
+                return ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0), // Consolidated padding
+                  itemCount: articles.length,
+                  itemBuilder: (context, index) {
+                    final article = articles[index];
+                    return articleItemBuilder(context, article, false);
+                  },
+                );
+              } else {
+                // Tablet/Desktop layout: GridView
+                int crossAxisCount = (constraints.maxWidth < 900) ? 2 : 3;
+                if (constraints.maxWidth < 350) crossAxisCount = 1; // Safety for very narrow desktop windows
+
+                return GridView.builder(
+                  padding: const EdgeInsets.all(16.0), // Padding around the grid
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossAxisCount,
+                    childAspectRatio: 2.8, // Adjust this value based on desired item height/width ratio
+                    crossAxisSpacing: 12.0, // Spacing between items horizontally
+                    mainAxisSpacing: 12.0,  // Spacing between items vertically
+                  ),
+                  itemCount: articles.length,
+                  itemBuilder: (context, index) {
+                    final article = articles[index];
+                    return articleItemBuilder(context, article, true);
+                  },
+                );
+              }
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(AppLocalizations.of(context)!.errorLoadingArticles(error.toString())),
+              ElevatedButton(
+                onPressed: () => ref.read(articlesListProvider.notifier).refresh(),
+                child: Text(AppLocalizations.of(context)!.buttonRetry),
+              )
+            ],
                 ),
               );
             },
@@ -183,10 +243,10 @@ class HomeScreen extends ConsumerWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text('Error loading articles: $error'), // Replace with localized string
+              Text(AppLocalizations.of(context)!.errorLoadingArticles(error.toString())),
               ElevatedButton(
                 onPressed: () => ref.read(articlesListProvider.notifier).refresh(),
-                child: const Text('Retry'), // Replace with localized string
+                child: Text(AppLocalizations.of(context)!.buttonRetry),
               )
             ],
           ),
@@ -194,7 +254,7 @@ class HomeScreen extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showAddArticleDialog(context, ref),
-        tooltip: 'Add Article', // Replace with localized string
+        tooltip: AppLocalizations.of(context)!.tooltipAddArticle,
         child: const Icon(Icons.add),
       ),
       bottomNavigationBar: const custom_widgets.CustomBottomNavigation(),

--- a/lib/app/ui/widgets/app_bar.dart
+++ b/lib/app/ui/widgets/app_bar.dart
@@ -1,21 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Import for localization
+import 'package:readlyit/features/articles/presentation/providers/article_providers.dart'; // For pocketIsAuthenticatedProvider & articlesListProvider
 
-class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+class CustomAppBar extends ConsumerWidget implements PreferredSizeWidget { // Make it ConsumerWidget
   final String titleText;
-  final VoidCallback? onPocketImport;
+  final VoidCallback? onPocketImport; // This will now be conditional based on auth state
 
   const CustomAppBar({
     super.key,
     required this.titleText,
-    this.onPocketImport,
+    this.onPocketImport, // Keep for now, but its direct use might change
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef
+    final pocketAuthAsyncValue = ref.watch(pocketIsAuthenticatedProvider);
+    // Cache ScaffoldMessenger if used multiple times, though here it's fine per action.
+    // final scaffoldMessenger = ScaffoldMessenger.of(context); 
+
     return AppBar(
       title: Text(
         titleText,
-        style: TextStyle( // Consistent title style
+        style: const TextStyle( // Consistent title style
           fontWeight: FontWeight.bold,
           // fontSize: 20, // Example: if you want to customize size
         ),
@@ -23,12 +30,77 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       elevation: 1.0, // Subtle elevation
       centerTitle: true, // Optional: center title
       actions: <Widget>[
-        if (onPocketImport != null)
-          IconButton(
-            icon: const Icon(Icons.cloud_download_outlined),
-            tooltip: 'Import from Pocket', // Replace with localized string
-            onPressed: onPocketImport,
+        // Pocket integration actions
+        pocketAuthAsyncValue.when(
+          data: (isAuthenticated) {
+            if (isAuthenticated) {
+              return PopupMenuButton<String>(
+                icon: const Icon(Icons.cloud_sync_outlined), // Or Icons.pocket or similar
+                tooltip: AppLocalizations.of(context)!.tooltipPocketOptions,
+                onSelected: (String choice) async {
+                  final articlesNotifier = ref.read(articlesListProvider.notifier);
+                  final scaffoldMessenger = ScaffoldMessenger.of(context); // Cache for use in async operations
+
+                  if (choice == 'sync') {
+                    scaffoldMessenger.showSnackBar(
+                      SnackBar(content: Text(AppLocalizations.of(context)!.syncingPocketArticles)),
+                    );
+                    final error = await articlesNotifier.completePocketAuthenticationAndFetchArticles();
+                    if (error != null) {
+                      scaffoldMessenger.showSnackBar(
+                        SnackBar(content: Text(AppLocalizations.of(context)!.pocketSyncFailed(error.toString()))),
+                      );
+                    } else {
+                      scaffoldMessenger.showSnackBar(
+                        SnackBar(content: Text(AppLocalizations.of(context)!.pocketSyncSuccessful)),
+                      );
+                      // Optionally, you might want to refresh the main articles list
+                      // ref.invalidate(articlesListProvider); // Or call a refresh method
+                    }
+                  } else if (choice == 'logout') {
+                    await articlesNotifier.logoutFromPocket();
+                    ref.invalidate(pocketIsAuthenticatedProvider); // Refresh the auth state provider
+                    scaffoldMessenger.showSnackBar(
+                      SnackBar(content: Text(AppLocalizations.of(context)!.loggedOutFromPocket)),
+                    );
+                  }
+                },
+                itemBuilder: (BuildContext context) {
+                  return [
+                    PopupMenuItem<String>(
+                      value: 'sync',
+                      child: Text(AppLocalizations.of(context)!.menuItemSyncPocketArticles),
+                    ),
+                    PopupMenuItem<String>(
+                      value: 'logout',
+                      child: Text(AppLocalizations.of(context)!.menuItemLogoutFromPocket),
+                    ),
+                  ];
+                },
+              );
+            } else {
+              // Not authenticated, show connect button
+              return IconButton(
+                icon: const Icon(Icons.login_outlined), // Or a Pocket specific icon
+                tooltip: AppLocalizations.of(context)!.tooltipConnectToPocket,
+                onPressed: onPocketImport, // This is the callback from HomeScreen
+              );
+            }
+          },
+          loading: () => const Padding(
+            padding: EdgeInsets.only(right: 16.0), // Ensure it's not too close to edge
+            child: SizedBox(
+              height: 24, // Adjust size to fit appbar
+              width: 24,  // Adjust size to fit appbar
+              child: CircularProgressIndicator(strokeWidth: 2.0, color: Colors.white,), // Color for visibility on AppBar
+            ),
           ),
+          error: (err, stack) => IconButton(
+            icon: const Icon(Icons.error_outline, color: Colors.orangeAccent), // Error color
+            tooltip: AppLocalizations.of(context)!.tooltipPocketAuthError,
+            onPressed: onPocketImport, // Allow retry by initiating the process again
+          ),
+        ),
         // Example: Add a settings icon button
         // IconButton(
         //   icon: const Icon(Icons.settings_outlined),

--- a/lib/app/ui/widgets/bottom_navigation.dart
+++ b/lib/app/ui/widgets/bottom_navigation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart'; // For potential state later
+import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Import for localization
 
 // Example: Provider to manage the selected index if needed globally or across complex UI
 final bottomNavIndexProvider = StateProvider<int>((ref) => 0);
@@ -10,22 +11,23 @@ class CustomBottomNavigation extends ConsumerWidget { // Changed to ConsumerWidg
   @override
   Widget build(BuildContext context, WidgetRef ref) { // Added WidgetRef
     final currentIndex = ref.watch(bottomNavIndexProvider);
+    final L10n = AppLocalizations.of(context)!; // For easier access
 
     return BottomNavigationBar(
       elevation: 2.0, // Add some elevation
       type: BottomNavigationBarType.fixed, // Good for 2-3 items, shows labels
-      // selectedItemColor: Theme.of(context).colorScheme.primary, // Example: Use primary color for selected
-      // unselectedItemColor: Colors.grey[600],
-      items: const <BottomNavigationBarItem>[
+      selectedItemColor: Theme.of(context).colorScheme.primary, // Use primary color for selected
+      unselectedItemColor: Colors.grey[600], // Example: A bit muted for unselected
+      items: <BottomNavigationBarItem>[
         BottomNavigationBarItem(
-          icon: Icon(Icons.article_outlined), // Changed icon
-          activeIcon: Icon(Icons.article), // Icon when active
-          label: 'Articles', // Replace with localized string
+          icon: const Icon(Icons.article_outlined), // Changed icon
+          activeIcon: const Icon(Icons.article), // Icon when active
+          label: L10n.bottomNavArticles, // Localized
         ),
         BottomNavigationBarItem(
-          icon: Icon(Icons.settings_outlined),
-          activeIcon: Icon(Icons.settings),
-          label: 'Settings', // Replace with localized string
+          icon: const Icon(Icons.settings_outlined),
+          activeIcon: const Icon(Icons.settings),
+          label: L10n.bottomNavSettings, // Localized
         ),
       ],
       currentIndex: currentIndex,
@@ -33,10 +35,10 @@ class CustomBottomNavigation extends ConsumerWidget { // Changed to ConsumerWidg
         ref.read(bottomNavIndexProvider.notifier).state = index;
         // TODO: Implement actual navigation based on index
         // For now, just show a SnackBar
-        String pageName = index == 0 ? "Articles" : "Settings";
+        String pageName = index == 0 ? L10n.bottomNavArticles : L10n.bottomNavSettings; // Localized pageName
         ScaffoldMessenger.of(context).removeCurrentSnackBar(); // Remove previous snackbar
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Navigated to $pageName (Placeholder)')), // Replace with localized string
+          SnackBar(content: Text(L10n.navigatedToPagePlaceholder(pageName))), // Localized SnackBar
         );
       },
     );

--- a/lib/features/articles/data/datasources/remote/article_content_fetcher_service.dart
+++ b/lib/features/articles/data/datasources/remote/article_content_fetcher_service.dart
@@ -1,14 +1,157 @@
-import 'dart:async';
+import 'package:dio/dio.dart';
+import 'package:html/parser.dart' as html_parser; // For HTML parsing
+import 'package:html/dom.dart' as html_dom;     // For DOM manipulation (Element, Document)
 
 class ArticleContentFetcherService {
+  final Dio _dio;
+
+  ArticleContentFetcherService({Dio? dio})
+      : _dio = dio ?? Dio();
+
   Future<String> fetchContent(String url) async {
-    print('[ArticleContentFetcherService] Fetching content for $url...');
-    // Simulate network request and parsing
-    await Future.delayed(const Duration(seconds: 3)); // Simulate some delay
-    // In a real app, use http to get page, then a library like
-    // 'html' or 'flutter_html' to parse, or a readability algorithm.
-    final fetchedHtml = "<html><body><h1>Simulated Fetched Title for $url</h1><p>This is the <b>simulated full content</b> of the article from $url. It would be much longer and contain actual HTML markup or properly parsed and cleaned text.</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></body></html>";
-    print('[ArticleContentFetcherService] Successfully fetched content for $url.');
-    return fetchedHtml;
+    try {
+      print('[ArticleContentFetcherService] Fetching content for URL: $url');
+      final response = await _dio.get(url, options: Options(
+        // Follow redirects
+        followRedirects: true,
+        maxRedirects: 5,
+        // Set a reasonable timeout
+        receiveTimeout: const Duration(seconds: 15),
+        headers: {
+          // Some websites might block requests without a common user-agent
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+          'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+          'accept-language': 'en-US,en;q=0.9',
+        }
+      ));
+
+      if (response.statusCode == 200 && response.data != null) {
+        print('[ArticleContentFetcherService] Successfully fetched HTML. Status: ${response.statusCode}');
+        return _extractMainContent(response.data.toString(), url);
+      } else {
+        print('[ArticleContentFetcherService] Failed to fetch HTML. Status: ${response.statusCode}');
+        throw Exception('Failed to fetch article HTML: Status code ${response.statusCode}');
+      }
+    } on DioException catch (e) {
+      // Handle Dio specific errors (timeout, connection error, etc.)
+      print('[ArticleContentFetcherService] DioError fetching content: ${e.message}');
+      if (e.type == DioExceptionType.connectionTimeout || e.type == DioExceptionType.receiveTimeout || e.type == DioExceptionType.sendTimeout) {
+        throw Exception('Network timeout when fetching article: ${e.message}');
+      } else if (e.type == DioExceptionType.unknown) { // Was DioErrorType.other before Dio 5.x
+         throw Exception('Network error when fetching article: ${e.message}');
+      }
+      throw Exception('Error fetching article: ${e.message}');
+    } 
+    catch (e) {
+      print('[ArticleContentFetcherService] Error fetching content: $e');
+      throw Exception('Failed to fetch or parse article content: ${e.toString()}');
+    }
   }
+
+  String _extractMainContent(String htmlString, String url) {
+    print('[ArticleContentFetcherService] Extracting main content...');
+    final document = html_parser.parse(htmlString);
+
+    // 1. Try common semantic tags
+    html_dom.Element? articleElement = document.querySelector('article');
+    if (articleElement != null) {
+      print('[ArticleContentFetcherService] Found <article> tag.');
+      return _cleanHtml(articleElement.innerHtml, url);
+    }
+
+    // 2. Try common ID selectors
+    const commonIds = ['content', 'main-content', 'article-body', 'entry-content', 'post-content', 'main'];
+    for (String id in commonIds) {
+      html_dom.Element? elementById = document.getElementById(id);
+      if (elementById != null) {
+        print('[ArticleContentFetcherService] Found element with ID: #$id');
+        return _cleanHtml(elementById.innerHtml, url);
+      }
+    }
+    
+    // 3. Try common class names (more prone to false positives, use with caution or more specific selectors)
+    // Example: document.querySelector('.post-body') or similar.
+    // For now, keeping it simple. A more robust solution might involve libraries like Readability.js (dart ports are rare/experimental)
+    // or more complex heuristics (text density, link density).
+
+    // 4. Fallback: If no specific main content area is found, return a significant portion of the body.
+    // This is a very basic fallback and might include unwanted elements.
+    // We try to find the largest text block.
+    html_dom.Element? body = document.body;
+    if (body != null) {
+        print('[ArticleContentFetcherService] No specific content tags found, attempting to find largest text block in body.');
+        // A simple heuristic: find the element with the most direct text content.
+        // This is very naive. A better approach would be to score elements based on text length,
+        // link density, etc.
+        html_dom.Element? bestCandidate = body;
+        int maxTextLength = 0;
+
+        void findBestCandidate(html_dom.Element element) {
+            String directText = element.nodes.whereType<html_dom.Text>().map((t) => t.text.trim()).join(' ');
+            if (directText.length > maxTextLength) {
+                // Penalize elements that are typically not main content
+                if (!['nav', 'header', 'footer', 'aside', 'script', 'style'].contains(element.localName)) {
+                     maxTextLength = directText.length;
+                     bestCandidate = element;
+                }
+            }
+            element.children.forEach(findBestCandidate);
+        }
+        // findBestCandidate(body); // This recursive search might be too broad or inefficient for initial implementation
+        // For now, let's just return the body's innerHTML if no better candidate is found via tags/IDs.
+        // This is likely to include navigation, ads, etc. but it's a starting point.
+        // A better fallback would be to implement a simplified readability-like algorithm.
+        // For now, we return the full body if other selectors fail.
+        // This means ArticleViewScreen *must* use flutter_html to make sense of it.
+        print('[ArticleContentFetcherService] Fallback: Returning entire body content. Needs improvement.');
+        return _cleanHtml(body.innerHtml, url);
+    }
+
+    print('[ArticleContentFetcherService] Could not extract meaningful content, returning empty string.');
+    return ''; // Fallback if body is null or no content found
+  }
+
+  // Basic cleaning and resolving relative URLs.
+  String _cleanHtml(String htmlContent, String baseUrl) {
+    final document = html_parser.parse(htmlContent);
+
+    // Remove script and style tags
+    document.querySelectorAll('script, style, noscript, iframe, nav, footer, aside, header').forEach((element) {
+      element.remove();
+    });
+    
+    // Optional: Remove comments
+    // document.nodes.whereType<html_dom.Comment>().forEach((comment) => comment.remove());
+
+    // Resolve relative URLs for images and links
+    final baseUri = Uri.parse(baseUrl);
+    document.querySelectorAll('a[href]').forEach((element) {
+      final href = element.attributes['href'];
+      if (href != null && href.isNotEmpty) {
+        try {
+          element.attributes['href'] = baseUri.resolve(href).toString();
+        } catch (e) {
+          print("Error resolving URL for <a> tag: $href, Error: $e");
+        }
+      }
+    });
+    document.querySelectorAll('img[src]').forEach((element) {
+      final src = element.attributes['src'];
+      if (src != null && src.isNotEmpty) {
+         try {
+          element.attributes['src'] = baseUri.resolve(src).toString();
+        } catch (e) {
+          print("Error resolving URL for <img> tag: $src, Error: $e");
+        }
+      }
+    });
+    
+    // Optional: Add target="_blank" to all links to open in external browser if rendered in a webview
+    // document.querySelectorAll('a[href]').forEach((element) {
+    //   element.attributes['target'] = '_blank';
+    // });
+
+    return document.body?.innerHtml ?? ''; // Return cleaned innerHTML of the body of the parsed fragment
+  }
+
 }

--- a/lib/features/articles/data/datasources/remote/icloud_service.dart
+++ b/lib/features/articles/data/datasources/remote/icloud_service.dart
@@ -1,80 +1,180 @@
 import 'dart:async';
+import 'dart:convert'; // For JSON encoding/decoding if sending complex data as string
+import 'dart:io' show Platform; // For checking platform
+
+import 'package:flutter/services.dart';
 import 'package:readlyit/features/articles/data/models/article_model.dart';
 
-// Placeholder for iCloud synchronization service.
-// Actual implementation requires native code (Swift for iOS/macOS) or a suitable plugin,
-// and proper iCloud entitlements in the Xcode project.
 class ICloudService {
-  // Simulates a remote iCloud store. In reality, this would interact with iCloud.
-  final Map<String, ArticleModel> _icloudStore = {};
-  DateTime? _lastSyncTime;
+  // IMPORTANT: Replace 'com.example.readlyit' with your actual application's bundle ID prefix.
+  static const MethodChannel _channel = MethodChannel('com.example.readlyit/icloud');
+
+  // StreamController for real-time updates from iCloud (optional, advanced)
+  // final _iCloudArticlesStreamController = StreamController<List<ArticleModel>>.broadcast();
+  // Stream<List<ArticleModel>> get iCloudArticlesStream => _iCloudArticlesStreamController.stream;
 
   ICloudService() {
-    print('[ICloudService] Initialized (Placeholder). Native setup would be required.');
+    // Optional: Listen for calls from native to Dart, if native needs to push updates
+    // _channel.setMethodCallHandler(_handleNativeMethodCall);
+    // Note: If you enable _handleNativeMethodCall, ensure it's a top-level function or static method
+    // if your ICloudService instance might be recreated.
   }
 
+  // Example of how you might handle calls from native code to Dart.
+  // Future<dynamic> _handleNativeMethodCall(MethodCall call) async {
+  //   switch (call.method) {
+  //     case "iCloudDataChanged":
+  //       // This would be called by native code when iCloud data changes
+  //       // Potentially fetch new data or signal the app to refresh
+  //       print("[ICloudService_Dart] Native code signaled iCloudDataChanged with arguments: ${call.arguments}");
+  //       // Example: Force a refresh or emit an event via the stream
+  //       // _iCloudArticlesStreamController.add(await fetchArticlesFromCloud());
+  //       // Or, more simply, notify another part of your app to trigger a refresh.
+  //       break;
+  //     default:
+  //       print('[ICloudService_Dart] Unknown method call from native: ${call.method}');
+  //   }
+  // }
+
   Future<void> initialize() async {
-    print('[ICloudService] Simulating initialization...');
-    // In a real scenario, might register for external change notifications here.
-    await Future.delayed(const Duration(milliseconds: 500));
-    _lastSyncTime = DateTime.now().subtract(const Duration(hours: 1)); // Pretend last sync was an hour ago
-    print('[ICloudService] Initialization complete. Last sync: $_lastSyncTime');
+    if (!(Platform.isIOS || Platform.isMacOS)) return;
+    try {
+      await _channel.invokeMethod('initialize');
+      print('[ICloudService_Dart] iCloud initialization method called on native side.');
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error initializing iCloud: ${e.message}');
+      // Depending on your app's needs, you might want to rethrow or handle this.
+    }
   }
 
   Future<void> syncArticleToCloud(ArticleModel article) async {
-    print('[ICloudService] Simulating sync of article ${article.id} to iCloud...');
-    await Future.delayed(const Duration(milliseconds: 300));
-    _icloudStore[article.id] = article; // Store/update in our mock cloud
-    print('[ICloudService] Article ${article.id} synced. Cloud store size: ${_icloudStore.length}');
-    await updateLastSyncTimestamp();
+    if (!(Platform.isIOS || Platform.isMacOS)) return;
+    try {
+      final String articleJson = jsonEncode(article.toJson());
+      await _channel.invokeMethod('syncArticle', {'articleJson': articleJson});
+      print('[ICloudService_Dart] syncArticleToCloud called for article: ${article.id}');
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error syncing article ${article.id} to iCloud: ${e.message}');
+      throw Exception('Failed to sync article to iCloud: ${e.message}');
+    }
   }
 
   Future<void> deleteArticleFromCloud(String articleId) async {
-    print('[ICloudService] Simulating deletion of article $articleId from iCloud...');
-    await Future.delayed(const Duration(milliseconds: 200));
-    _icloudStore.remove(articleId);
-    print('[ICloudService] Article $articleId deleted. Cloud store size: ${_icloudStore.length}');
-    await updateLastSyncTimestamp();
+    if (!(Platform.isIOS || Platform.isMacOS)) return;
+    try {
+      await _channel.invokeMethod('deleteArticle', {'articleId': articleId});
+      print('[ICloudService_Dart] deleteArticleFromCloud called for article ID: $articleId');
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error deleting article $articleId from iCloud: ${e.message}');
+      throw Exception('Failed to delete article from iCloud: ${e.message}');
+    }
   }
 
   Future<List<ArticleModel>> fetchArticlesFromCloud() async {
-    print('[ICloudService] Simulating fetching all articles from iCloud...');
-    await Future.delayed(const Duration(milliseconds: 700));
-    final articles = _icloudStore.values.toList();
-    print('[ICloudService] Fetched ${articles.length} articles from cloud.');
-    return articles;
+    if (!(Platform.isIOS || Platform.isMacOS)) return [];
+    try {
+      // The native side should return a List of Strings, where each string is a JSON representation of an ArticleModel.
+      final List<dynamic>? result = await _channel.invokeListMethod<dynamic>('fetchArticles');
+      print('[ICloudService_Dart] fetchArticlesFromCloud called. Received ${result?.length ?? 0} items.');
+      if (result != null) {
+        return result.map((data) {
+          if (data is String) { // Expecting JSON strings from native
+            return ArticleModel.fromJson(jsonDecode(data) as Map<String, dynamic>);
+          } else if (data is Map) { // Less ideal, but handle if native sends Map<dynamic, dynamic>
+             return ArticleModel.fromJson(Map<String, dynamic>.from(data));
+          }
+          print('[ICloudService_Dart] Unexpected data type from native for article: ${data.runtimeType}, data: $data');
+          throw Exception('Unexpected data type from native for article: ${data.runtimeType}');
+        }).toList();
+      }
+      return [];
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error fetching articles from iCloud: ${e.message}');
+      // Depending on your error handling strategy, you might want to:
+      // - return []; (as is)
+      // - throw e;
+      // - throw CustomException('Failed to fetch articles from iCloud: ${e.message}');
+      return []; 
+    } catch (e) {
+      print('[ICloudService_Dart] Error processing fetched articles: $e');
+      throw Exception('Failed to process articles from iCloud: $e');
+    }
   }
+  
+  // This is a conceptual placeholder. True conflict resolution is complex.
+  // It might involve native UI or more sophisticated merging logic based on timestamps.
+  ArticleModel resolveConflict(ArticleModel localArticle, ArticleModel cloudArticle) {
+    print('[ICloudService_Dart] Resolving conflict for article ID: ${localArticle.id}');
+    // Basic strategy: last write wins (most recent savedAt or a dedicated modifiedAt timestamp)
+    // This assumes 'savedAt' is updated upon any modification.
+    // If not, a separate 'modifiedAt' field that's updated on every change is better.
+    // Ensure both dates are in UTC for fair comparison if they come from different timezones.
+    final localSavedAt = localArticle.savedAt.toUtc();
+    final cloudSavedAt = cloudArticle.savedAt.toUtc();
 
-  // This stream is highly conceptual for a placeholder.
-  // Real iCloud sync might involve listening to system notifications.
-  Stream<List<ArticleModel>> get iCloudArticlesStream {
-    // For simulation, periodically emit the current cloud state.
-    // In a real app, this would be driven by actual iCloud change notifications.
-    return Stream.periodic(const Duration(minutes: 5), (_) {
-      print('[ICloudService] iCloudArticlesStream emitting (simulated periodic check)');
-      return _icloudStore.values.toList();
-    }).asBroadcastStream(); // Use asBroadcastStream if multiple listeners
-  }
-
-  Future<DateTime?> getLastSyncTimestamp() async {
-    print('[ICloudService] Getting last sync timestamp: $_lastSyncTime');
-    return _lastSyncTime;
+    if (cloudSavedAt.isAfter(localSavedAt)) {
+      print('[ICloudService_Dart] Conflict resolved: Cloud version is newer for article ${localArticle.id}.');
+      return cloudArticle;
+    } else if (localSavedAt.isAfter(cloudSavedAt)) {
+      print('[ICloudService_Dart] Conflict resolved: Local version is newer for article ${localArticle.id}.');
+      return localArticle;
+    } else {
+      // Timestamps are identical. Choose one consistently, e.g., local.
+      // Or, if content differs, flag as a genuine conflict needing user intervention or deeper merge.
+      print('[ICloudService_Dart] Conflict resolved: Timestamps are identical for ${localArticle.id}. Defaulting to local.');
+      return localArticle; 
+    }
   }
 
   Future<void> updateLastSyncTimestamp() async {
-    _lastSyncTime = DateTime.now();
-    print('[ICloudService] Last sync timestamp updated to: $_lastSyncTime');
+    if (!(Platform.isIOS || Platform.isMacOS)) return;
+    try {
+      final timestamp = DateTime.now().toUtc().millisecondsSinceEpoch; // Use UTC for consistency
+      await _channel.invokeMethod('updateLastSyncTimestamp', {'timestamp': timestamp});
+      print('[ICloudService_Dart] updateLastSyncTimestamp called with UTC: $timestamp');
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error updating last sync timestamp: ${e.message}');
+    }
   }
 
-  // Placeholder for conflict resolution. This is a very complex topic.
-  // For example, "last write wins" or a more complex merge.
-  ArticleModel resolveConflict(ArticleModel local, ArticleModel remote) {
-    print('[ICloudService] Resolving conflict for article ${local.id} (placeholder: local wins)');
-    // Simple strategy: local changes win. Or compare timestamps if available and reliable.
-    // A more robust strategy would look at a 'modifiedAt' timestamp on the article.
-    // For this placeholder, we'll just assume the local version is preferred or they are merged.
-    // If local.savedAt is more recent than remote.savedAt (assuming savedAt is updated on modification)
-    // return local; else return remote;
-    return local; // Placeholder: local wins
+  Future<DateTime?> getLastSyncTimestamp() async {
+    if (!(Platform.isIOS || Platform.isMacOS)) return null;
+    try {
+      final int? timestamp = await _channel.invokeMethod<int>('getLastSyncTimestamp');
+      print('[ICloudService_Dart] getLastSyncTimestamp called. Received: $timestamp');
+      if (timestamp != null) {
+        return DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true); // Assume timestamp from native is UTC
+      }
+      return null;
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error getting last sync timestamp: ${e.message}');
+      return null;
+    }
+  }
+
+  Future<void> triggerRemoteChangeCheck() async {
+    if (!(Platform.isIOS || Platform.isMacOS)) return;
+    try {
+      await _channel.invokeMethod('triggerRemoteChangeCheck');
+      print('[ICloudService_Dart] triggerRemoteChangeCheck called on native side.');
+    } on PlatformException catch (e) {
+      print('[ICloudService_Dart] Error triggering remote change check: ${e.message}');
+    }
   }
 }
+
+// Reminder: This Dart code is only one half of the iCloud synchronization solution.
+// You will need to implement the corresponding native Swift/Objective-C (for iOS/macOS)
+// code to handle these method calls, interact with iCloud (e.g., CloudKit or iCloud Documents),
+// and manage data storage and synchronization on the native side.
+
+// The ICloudServiceProvider in article_providers.dart should provide this service.
+// Ensure the provider calls `service.initialize()` upon creation.
+// Example from article_providers.dart (ensure this is how you have it):
+// final iCloudServiceProvider = Provider<ICloudService>((ref) {
+//   final service = ICloudService();
+//   // It's good practice to initialize the service when it's first created.
+//   // This could also be done lazily if initialization is heavy or needs context.
+//   service.initialize(); 
+//   return service;
+// });

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,5 +1,103 @@
 {
     "@@locale": "en",
     "appTitle": "ReadlyIt",
-    "helloWorld": "Hello World!"
+    "helloWorld": "Hello World!",
+    "addArticleTitle": "Add New Article",
+    "deleteArticleTitle": "Delete Article?",
+    "enterArticleUrlHint": "Enter article URL",
+    "enterArticleTitleHint": "Enter title (optional)",
+    "confirmDeleteArticleContent": "Are you sure you want to delete \"{articleTitle}\"?",
+    "@confirmDeleteArticleContent": {
+        "description": "Confirmation message for deleting an article",
+        "placeholders": {
+            "articleTitle": {
+                "type": "String",
+                "example": "My Awesome Article"
+            }
+        }
+    },
+    "buttonCancel": "Cancel",
+    "buttonSave": "Save",
+    "buttonDelete": "Delete",
+    "errorUrlCannotBeEmpty": "URL cannot be empty.",
+    "articlesListEmpty": "No articles saved yet. Add one!",
+    "errorLoadingArticles": "Error loading articles: {error}",
+    "@errorLoadingArticles": {
+        "description": "Error message when articles fail to load",
+        "placeholders": {
+            "error": {
+                "type": "Object",
+                "example": "Network error"
+            }
+        }
+    },
+    "buttonRetry": "Retry",
+    "tooltipAddArticle": "Add Article",
+    "tooltipDeleteArticle": "Delete Article",
+    "homeScreenTitle": "My Articles",
+    "fetchingContentText": "Fetching content...",
+    "failedToFetchContentText": "Failed to fetch content. Please try again.",
+    "contentNotFetchedYetText": "Full article content has not been fetched yet.",
+    "buttonFetchFullArticle": "Fetch Full Article",
+    "errorCouldNotLaunchUrl": "Could not launch URL: {url}. Invalid URL or no app to handle it.",
+    "@errorCouldNotLaunchUrl": {
+        "description": "Error when URL launching fails due to invalid URL or no handler",
+        "placeholders": {
+            "url": {
+                "type": "String",
+                "example": "https://example.com"
+            }
+        }
+    },
+    "errorCouldNotLaunchUrlGeneral": "Could not launch URL: {error}",
+    "@errorCouldNotLaunchUrlGeneral": {
+        "description": "General error when URL launching fails",
+        "placeholders": {
+            "error": {
+                "type": "Object",
+                "example": "Unknown error"
+            }
+        }
+    },
+    "errorFetchingContent": "Error fetching content: {errorMessage}",
+    "@errorFetchingContent": {
+        "description": "Error when fetching article content fails",
+        "placeholders": {
+            "errorMessage": {
+                "type": "String",
+                "example": "Network timeout"
+            }
+        }
+    },
+    "fetchedContentEmpty": "Fetched content is empty.",
+    "tooltipPocketOptions": "Pocket Options",
+    "tooltipConnectToPocket": "Connect to Pocket",
+    "tooltipPocketAuthError": "Pocket Auth Error. Tap to retry.",
+    "menuItemSyncPocketArticles": "Sync Pocket Articles",
+    "menuItemLogoutFromPocket": "Logout from Pocket",
+    "syncingPocketArticles": "Syncing Pocket articles...",
+    "pocketSyncFailed": "Pocket Sync Failed: {error}",
+    "@pocketSyncFailed": {
+        "description": "Error message when Pocket sync fails",
+        "placeholders": {
+            "error": {
+                "type": "Object",
+                "example": "API error"
+            }
+        }
+    },
+    "pocketSyncSuccessful": "Pocket Sync Successful!",
+    "loggedOutFromPocket": "Logged out from Pocket.",
+    "bottomNavArticles": "Articles",
+    "bottomNavSettings": "Settings",
+    "navigatedToPagePlaceholder": "Navigated to {pageName} (Placeholder)",
+    "@navigatedToPagePlaceholder": {
+        "description": "Placeholder message when navigating via bottom bar",
+        "placeholders": {
+            "pageName": {
+                "type": "String",
+                "example": "Settings"
+            }
+        }
+    }
 }


### PR DESCRIPTION
…I enhancements

This commit includes the initial implementation of several major features and enhancements:

1.  **Pocket Import:**
    *   Full OAuth 2.0 flow for Pocket authentication.
    *   Fetching and importing articles from Pocket.
    *   UI updates in AppBar and HomeScreen for Pocket integration.
    *   Requires you to add Pocket Consumer Key and configure URL schemes.

2.  **Article Content Fetching:**
    *   Service to fetch HTML content from article URLs.
    *   Basic HTML parsing to extract main content and clean it.
    *   ArticleViewScreen now renders fetched content using `flutter_html`.
    *   Requires `html` and `flutter_html` packages.

3.  **iCloud Synchronization (Dart Side):**
    *   `ICloudService` created with platform channel definitions for communication with native iOS/macOS code.
    *   `ArticlesListNotifier` updated for two-way synchronization logic, conflict resolution placeholder, and auto-sync on start.
    *   Requires you to implement native CloudKit Swift/Objective-C code.

4.  **UI Enhancements and Adaptive Layout:**
    *   Full English localization for existing UI elements.
    *   Instructions provided for manual Chinese localization due to tool issues.
    *   `HomeScreen` now features a responsive layout (ListView/GridView based on screen width).
    *   `ArticleViewScreen` uses `ConstrainedBox` for better readability.
    *   Minor visual polish to `CustomBottomNavigation`.
    *   You are advised to test Dynamic Type manually.

Further native implementation is required for iCloud sync to be functional. The `app_zh.arb` file needs to be manually updated by you with the provided translations.